### PR TITLE
Fixed running on Linux

### DIFF
--- a/Backend/src/Util/JavaUtils/JavaVersionUtils.cs
+++ b/Backend/src/Util/JavaUtils/JavaVersionUtils.cs
@@ -16,7 +16,7 @@ public class JavaVersionUtils
         {
             //TODO get default path from settings
             //javaPath = AppSettingsSerializer.Instance.AppSettings.DefaultJavaPath;
-            javaPath = "java ";
+            javaPath = "java";
         }
 
         return CheckForPathJava(javaPath);


### PR DESCRIPTION
Removing the space in the `javaPath` string, allows Fork to launch servers on Linux.