### PR TITLE
FIX: Occasionally throws InvalidOperationException when stopping server

### DIFF
--- a/Backend/src/Util/ExtensionMethods/ProcessExtensions.cs
+++ b/Backend/src/Util/ExtensionMethods/ProcessExtensions.cs
@@ -9,12 +9,14 @@ public static class ProcessExtensions
     public static async Task<double> CalculateCpuLoad(this Process process, TimeSpan measurementWindow)
     {
         process.Refresh();
+        if (process.HasExited) return 0;
         TimeSpan startCpuTime = process.TotalProcessorTime;
         Stopwatch timer = Stopwatch.StartNew();
 
         await Task.Delay(measurementWindow);
 
         process.Refresh();
+        if (process.HasExited) return 0;
         TimeSpan endCpuTime = process.TotalProcessorTime;
         timer.Stop();
         return (endCpuTime - startCpuTime).TotalMilliseconds /
@@ -24,6 +26,6 @@ public static class ProcessExtensions
     public static Task<double> CalculateMemLoad(this Process process, int maxRam)
     {
         process.Refresh();
-        return Task.FromResult(process.WorkingSet64 / (1024d * 1024d) / maxRam * 100);
+        return process.HasExited ? Task.FromResult<double>(0) : Task.FromResult(process.WorkingSet64 / (1024d * 1024d) / maxRam * 100);
     }
 }


### PR DESCRIPTION
When stopping a server, due to timing, occasionally it throws an InvalidOperationException when calculating CPU or memory load.
This happens when the process exits during the calculations.